### PR TITLE
chore(deps): update JDK from 24 to 25 and refactor with Lombok

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,10 +18,10 @@ jobs:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.4.2] - 2025-10-15
+- chore: Actualización de JDK de 24 a 25 en pom.xml, Dockerfile y workflow de CI
+- refactor: Mejora de controladores y servicios usando @RequiredArgsConstructor de Lombok (eliminación de constructores manuales en AjustesController y AjustesService)
+
 ## [0.4.1] - 2025-09-21
 - chore: Actualización de dependencias:
   - Spring Boot Starter Parent a 3.5.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Etapa 1: Compilación con Maven y JDK
 # Usamos una imagen oficial que contiene Maven y Java (Temurin)
-FROM maven:3-eclipse-temurin-24-alpine AS build
+FROM maven:3-eclipse-temurin-25-alpine AS build
 
 # Establecemos el directorio de trabajo
 WORKDIR /app
@@ -19,7 +19,7 @@ RUN mvn clean package
 
 # Etapa 2: Creación de la imagen final y ligera
 # Usamos una imagen solo con el JRE, que es más pequeña
-FROM eclipse-temurin:24-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 
 # Instalar curl en la imagen final
 RUN apk update && apk add curl

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ETEREA.stock-service
 
 [![ETEREA.stock-service CI](https://github.com/ETEREA-services/ETEREA.stock-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/ETEREA.stock-service/actions/workflows/maven.yml)
-[![Java Version](https://img.shields.io/badge/Java-24-blue.svg)](https://www.oracle.com/java/technologies/downloads/)
+[![Java Version](https://img.shields.io/badge/Java-25-blue.svg)](https://www.oracle.com/java/technologies/downloads/)
 ![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.6-green.svg)](https://spring.io/projects/spring-boot)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.0.0-blue.svg)](https://spring.io/projects/spring-cloud)
 [![SpringDoc OpenAPI](https://img.shields.io/badge/SpringDoc%20OpenAPI-2.8.10-blue.svg)](https://springdoc.org/)
-[![Version](https://img.shields.io/badge/Version-0.4.1-blue.svg)](https://github.com/ETEREA-services/ETEREA.stock-service/releases/tag/v0.4.1)
+[![Version](https://img.shields.io/badge/Version-0.4.2-blue.svg)](https://github.com/ETEREA-services/ETEREA.stock-service/releases/tag/v0.4.2)
 
 ## Descripción
 
@@ -19,7 +19,7 @@ El Servicio de Gestión de Stock es un componente esencial del sistema ETEREA qu
 
 ## Tecnologías Principales
 
-- **Java 24**: Lenguaje de programación principal
+- **Java 25**: Lenguaje de programación principal
 - **Spring Boot 3.5.6**: Framework de desarrollo
 - **Spring Cloud 2025.0.0**: Microservicios y cloud
 - **SpringDoc OpenAPI 2.8.10**: Documentación de API
@@ -39,7 +39,7 @@ El Servicio de Gestión de Stock es un componente esencial del sistema ETEREA qu
 
 ### Requisitos
 
-- Java 24
+- Java 25
 - Maven 3.9+
 - Docker (opcional)
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>eterea</groupId>
     <artifactId>stock-service</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <name>ETEREA.stock-service</name>
     <description>stock-service</description>
     <url/>
@@ -27,7 +27,7 @@
         <url/>
     </scm>
     <properties>
-        <java.version>24</java.version>
+        <java.version>25</java.version>
         <spring-cloud.version>2025.0.0</spring-cloud.version>
         <sonar.organization>eterea-services</sonar.organization>
         <sonar.projectKey>ETEREA-services_ETEREA.stock-service</sonar.projectKey>

--- a/src/main/java/eterea/stock/service/controller/facade/AjustesController.java
+++ b/src/main/java/eterea/stock/service/controller/facade/AjustesController.java
@@ -3,6 +3,7 @@ package eterea.stock.service.controller.facade;
 import eterea.stock.service.model.dto.StockResponseDto;
 import eterea.stock.service.service.facade.AjustesService;
 import eterea.stock.service.util.transfer.FileInfo;
+import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,13 +14,10 @@ import java.time.OffsetDateTime;
 
 @RestController
 @RequestMapping("/api/stock/ajustes")
+@RequiredArgsConstructor
 public class AjustesController {
 
     private final AjustesService service;
-
-    public AjustesController(AjustesService service) {
-        this.service = service;
-    }
 
     @PostMapping("/upload/{centroStockId}/{comprobanteId}/{fechaRegistro}")
     public ResponseEntity<StockResponseDto> upload(@RequestBody FileInfo fileInfo,

--- a/src/main/java/eterea/stock/service/service/facade/AjustesService.java
+++ b/src/main/java/eterea/stock/service/service/facade/AjustesService.java
@@ -10,6 +10,7 @@ import eterea.stock.service.model.StockMovimientoDto;
 import eterea.stock.service.model.dto.*;
 import eterea.stock.service.util.Tool;
 import eterea.stock.service.util.transfer.FileInfo;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
@@ -25,19 +26,12 @@ import java.util.List;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class AjustesService {
 
     private final ArticuloClient articuloClient;
     private final EmpresaClient empresaClient;
     private final StockClient stockClient;
-
-    public AjustesService(ArticuloClient articuloClient,
-                          EmpresaClient empresaClient,
-                          StockClient stockClient) {
-        this.articuloClient = articuloClient;
-        this.empresaClient = empresaClient;
-        this.stockClient = stockClient;
-    }
 
     public StockResponseDto upload(FileInfo fileInfo, Integer centroStockId, Integer comprobanteId, OffsetDateTime fechaRegistro) {
         log.debug("Processing AjustesService.upload");


### PR DESCRIPTION
## Descripción
Esta PR implementa la actualización de la versión 0.4.2 del servicio de stock, que incluye la migración de JDK 24 a 25 y refactorizaciones en el código usando Lombok. Resuelve la issue #24.

## Cambios Realizados
- [x] Actualización de JDK de 24 a 25 en pom.xml, Dockerfile, workflow de CI y documentación.
- [x] Refactorización de AjustesController y AjustesService para usar @RequiredArgsConstructor de Lombok, eliminando constructores manuales.
- [x] Actualización de CHANGELOG.md con los detalles de la versión 0.4.2.
- [x] Actualización de badges y documentación en README.md.

## Impacto Potencial
- [x] Requiere JDK 25 para compilación y ejecución (cambio breaking).
- [x] Actualizar entornos de desarrollo y despliegue a JDK 25.
- [x] No afecta funcionalidad existente, solo mejora la construcción y dependencias.

## Verificación
Para verificar los cambios:
1. `git checkout 24-release-v042-actualización-de-jdk-a-25-y-refactor-con-lombok`
2. `mvn clean compile` - Debe compilar sin errores con JDK 25.
3. `mvn test` - Todos los tests deben pasar.
4. Verificar que la aplicación se ejecute correctamente con JDK 25.

## Notas Adicionales
Este PR es parte del milestone "Release v0.4.1" y prepara el proyecto para futuras versiones con JDK 25.