### PR TITLE
chore(release): v1.0.0 - actualización masiva de dependencias y DTOs

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 24
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 
@@ -268,13 +268,10 @@ jobs:
             git push --set-upstream https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git master
           fi
 
-      - name: Prepare artifact for deployment
-        run: |
-          mv docs _site
       - name: Upload artifacts
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
-          path: _site
+          path: docs
 
   deploy-pages:
     needs: generate-docs
@@ -289,4 +286,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
+

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,24 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -54,17 +54,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata for JVM Docker image
         id: meta-jvm
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ secrets.DOCKER_IMAGE_NAME }}
           # Add a '-jvm' suffix to tags to differentiate them
@@ -75,10 +75,10 @@ jobs:
             latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push JVM Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           # Point to the new JVM-specific Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [1.0.0] - 2026-06-10
+- chore: Actualización masiva de dependencias:
+  - Spring Boot Starter Parent 3.5.6 → 4.0.6
+  - Spring Cloud 2025.0.0 → 2025.1.0
+  - SpringDoc OpenAPI 2.8.10 → 3.0.2
+  - Apache POI 5.4.1 → 5.5.1
+  - commons-lang3 3.18.0 → 3.20.0
+- feat: Nueva dependencia commons-fileupload 1.6.0 para carga de archivos
+- feat: Método `jsonify()` en DTOs (`ArticuloBarraDto`, `ArticuloDto`, `ArticuloStockDto`) usando `Jsonifier`
+- refactor: Migración de DTOs de `@Data` a `@Getter/@Setter/@Builder/@NoArgsConstructor/@AllArgsConstructor`
+- refactor: Renombre de campos en `ArticuloDto` (`cuentaVentas` → `numeroCuentaVentas`, `cuentaCompras` → `numeroCuentaCompras`, `cuentaGastos` → `numeroCuentaGastos`)
+- refactor: Simplificación de logging con `jsonify()` reemplazando `JsonMapper` manual en controladores y servicios
+- refactor: Migración a `@RequiredArgsConstructor` de Lombok en `StockArticuloController`, `ControlInventarioController`, `StockArticuloService`, `ControlInventarioService`
+- chore: Eliminación de `<executable>true</executable>` del plugin spring-boot-maven-plugin
+- ci: Actualización de Actions (checkout@v6, setup-java@v5, cache@v5, docker/login-action@v4, metadata-action@v6, buildx-action@v4, build-push-action@v7, upload-pages-artifact@v4, deploy-pages@v5)
+- ci: Cambio en el path de artefactos Pages (`_site` → `docs`)
+
 ## [0.4.2] - 2025-10-15
 - chore: Actualización de JDK de 24 a 25 en pom.xml, Dockerfile y workflow de CI
 - refactor: Mejora de controladores y servicios usando @RequiredArgsConstructor de Lombok (eliminación de constructores manuales en AjustesController y AjustesService)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![ETEREA.stock-service CI](https://github.com/ETEREA-services/ETEREA.stock-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/ETEREA.stock-service/actions/workflows/maven.yml)
 [![Java Version](https://img.shields.io/badge/Java-25-blue.svg)](https://www.oracle.com/java/technologies/downloads/)
-![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.6-green.svg)](https://spring.io/projects/spring-boot)
-[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.0.0-blue.svg)](https://spring.io/projects/spring-cloud)
-[![SpringDoc OpenAPI](https://img.shields.io/badge/SpringDoc%20OpenAPI-2.8.10-blue.svg)](https://springdoc.org/)
-[![Version](https://img.shields.io/badge/Version-0.4.2-blue.svg)](https://github.com/ETEREA-services/ETEREA.stock-service/releases/tag/v0.4.2)
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.6-green.svg)](https://spring.io/projects/spring-boot)
+[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-blue.svg)](https://spring.io/projects/spring-cloud)
+[![SpringDoc OpenAPI](https://img.shields.io/badge/SpringDoc%20OpenAPI-3.0.2-blue.svg)](https://springdoc.org/)
+[![Version](https://img.shields.io/badge/Version-1.0.0-blue.svg)](https://github.com/ETEREA-services/ETEREA.stock-service/releases/tag/v1.0.0)
 
 ## Descripción
 
@@ -20,13 +20,14 @@ El Servicio de Gestión de Stock es un componente esencial del sistema ETEREA qu
 ## Tecnologías Principales
 
 - **Java 25**: Lenguaje de programación principal
-- **Spring Boot 3.5.6**: Framework de desarrollo
-- **Spring Cloud 2025.0.0**: Microservicios y cloud
-- **SpringDoc OpenAPI 2.8.10**: Documentación de API
-- **Apache POI 5.4.1**: Procesamiento de archivos Excel
+- **Spring Boot 4.0.6**: Framework de desarrollo
+- **Spring Cloud 2025.1.0**: Microservicios y cloud
+- **SpringDoc OpenAPI 3.0.2**: Documentación de API
+- **Apache POI 5.5.1**: Procesamiento de archivos Excel
 - **Lombok**: Reducción de código boilerplate
 - **Caffeine**: Caché de alto rendimiento
 - **Spring Validation**: Validación de datos
+- **Commons FileUpload 1.6.0**: Carga de archivos
 
 ## Documentación
 

--- a/docs/diagrams/mermaid/README.md
+++ b/docs/diagrams/mermaid/README.md
@@ -7,6 +7,6 @@ Este directorio contiene todos los diagramas Mermaid generados automáticamente 
 - `architecture.mmd`: Diagrama de arquitectura general del servicio.
 - `ajuste-stock-flow.mmd`: Flujo de proceso para el caso de uso de ajuste de stock.
 - `stock-adjustment-class-diagram.mmd`: Diagrama de clases UML simplificado para el ajuste de stock.
-- `dto-classes.mmd`: Diagrama de clases de los principales DTOs y relaciones. **Actualizado para versión 0.3.0**
+- `dto-classes.mmd`: Diagrama de clases de los principales DTOs y relaciones. **Actualizado para versión 1.0.0**
 - `stock-adjustment-sequence-diagram.mmd`: Diagrama de secuencia para el flujo de ajuste de stock.
 - `dependencies.mmd`: Diagrama de dependencias externas (Consul v3.5.4, Feign, APIs externas).

--- a/docs/diagrams/mermaid/dto-classes.mmd
+++ b/docs/diagrams/mermaid/dto-classes.mmd
@@ -9,6 +9,35 @@ classDiagram
         +String articuloId
         +... // otros campos
     }
+    class ArticuloDto {
+        +String articuloId
+        +String descripcion
+        +BigDecimal precioVentaSinIva
+        +BigDecimal precioVentaConIva
+        +Long numeroCuentaVentas
+        +Long numeroCuentaCompras
+        +Long numeroCuentaGastos
+        +Integer centroStockId
+        +Long rubroId
+        +Long subRubroId
+        +... // otros campos
+        +String jsonify()
+    }
+    class ArticuloBarraDto {
+        +Long articuloBarraId
+        +String codigoBarras
+        +String articuloId
+        +ArticuloDto articulo
+        +String jsonify()
+    }
+    class ArticuloStockDto {
+        +ArticuloDto articulo
+        +String codigo
+        +String descripcion
+        +OffsetDateTime fecha
+        +BigDecimal precio
+        +String jsonify()
+    }
     class RubroDto {
         +String nombre
         +List~ArticuloAjusteDto~ articulos
@@ -17,10 +46,7 @@ classDiagram
     class InventarioDto
     class InventarioTurnoDto
     class StockContextDto
-    class StockMovimientoDto
     class ArticuloAjusteDto
-    class ArticuloStockDto
-    class RubroDto
     class StockAndArticulosDto
     class StockResponseDto
 
@@ -34,6 +60,7 @@ classDiagram
     InventarioDto "1" --> "1" CentroStockDto
     InventarioDto "1" --> "1" ArticuloDto
     ArticuloStockDto "1" --> "1" ArticuloDto
+    ArticuloBarraDto "1" --> "1" ArticuloDto
     class StockAndArticulosDto {
         +StockMovimientoDto stockMovimiento
         +List~ArticuloMovimientoDto~ articuloMovimientos

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.6</version>
+        <version>4.0.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>eterea</groupId>
     <artifactId>stock-service</artifactId>
-    <version>0.4.2</version>
+    <version>1.0.0</version>
     <name>ETEREA.stock-service</name>
     <description>stock-service</description>
     <url/>
@@ -28,7 +28,7 @@
     </scm>
     <properties>
         <java.version>25</java.version>
-        <spring-cloud.version>2025.0.0</spring-cloud.version>
+        <spring-cloud.version>2025.1.0</spring-cloud.version>
         <sonar.organization>eterea-services</sonar.organization>
         <sonar.projectKey>ETEREA-services_ETEREA.stock-service</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -71,17 +71,17 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.10</version>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>5.4.1</version>
+            <version>5.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>5.4.1</version>
+            <version>5.5.1</version>
         </dependency>
 
         <dependency>
@@ -106,7 +106,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.18.0</version>
+                <version>3.20.0</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
@@ -114,6 +114,11 @@
                 <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>commons-fileupload</groupId>
+                <artifactId>commons-fileupload</artifactId>
+                <version>1.6.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -124,9 +129,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <executable>true</executable>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/eterea/stock/service/controller/dto/StockArticuloController.java
+++ b/src/main/java/eterea/stock/service/controller/dto/StockArticuloController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import eterea.stock.service.model.dto.ArticuloStockDto;
 import eterea.stock.service.service.dto.StockArticuloService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -17,23 +18,16 @@ import java.time.OffsetDateTime;
 @RestController
 @RequestMapping("/api/stock/stockarticulo")
 @Slf4j
+@RequiredArgsConstructor
 public class StockArticuloController {
 
     private final StockArticuloService service;
-
-    public StockArticuloController(StockArticuloService service) {
-        this.service = service;
-    }
 
     @GetMapping("/getarticulo/{codigo}/{fecha}")
     public ResponseEntity<ArticuloStockDto> getStockArticulo(@PathVariable String codigo,
                                                              @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime fecha) {
         var stockArticulo = service.getStockArticulo(codigo, fecha);
-        try {
-            log.debug("StockArticulo -> {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(stockArticulo));
-        } catch (JsonProcessingException e) {
-            log.debug("StockArticulo error -> {}", e.getMessage());
-        }
+        log.debug("StockArticulo -> {}", stockArticulo.jsonify());
         return ResponseEntity.ok(stockArticulo);
     }
 

--- a/src/main/java/eterea/stock/service/controller/facade/ControlInventarioController.java
+++ b/src/main/java/eterea/stock/service/controller/facade/ControlInventarioController.java
@@ -2,6 +2,7 @@ package eterea.stock.service.controller.facade;
 
 import eterea.stock.service.model.InventarioDto;
 import eterea.stock.service.service.facade.ControlInventarioService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,13 +13,10 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/stock/controlinventario")
+@RequiredArgsConstructor
 public class ControlInventarioController {
 
     private final ControlInventarioService service;
-
-    public ControlInventarioController(ControlInventarioService service) {
-        this.service = service;
-    }
 
     @PostMapping("/add")
     public ResponseEntity<List<InventarioDto>> addControlInventario(@RequestBody List<InventarioDto> inventarios) {

--- a/src/main/java/eterea/stock/service/model/ArticuloBarraDto.java
+++ b/src/main/java/eterea/stock/service/model/ArticuloBarraDto.java
@@ -1,8 +1,13 @@
 package eterea.stock.service.model;
 
-import lombok.Data;
+import eterea.stock.service.util.Jsonifier;
+import lombok.*;
 
-@Data
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ArticuloBarraDto {
 
     private Long articuloBarraId = null;
@@ -10,4 +15,7 @@ public class ArticuloBarraDto {
     private String articuloId = null;
     private ArticuloDto articulo = null;
 
+    public String jsonify() {
+        return Jsonifier.builder(this).build();
+    }
 }

--- a/src/main/java/eterea/stock/service/model/ArticuloDto.java
+++ b/src/main/java/eterea/stock/service/model/ArticuloDto.java
@@ -1,10 +1,15 @@
 package eterea.stock.service.model;
 
-import lombok.Data;
+import eterea.stock.service.util.Jsonifier;
+import lombok.*;
 
 import java.math.BigDecimal;
 
-@Data
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ArticuloDto {
 
     private String articuloId;
@@ -13,9 +18,9 @@ public class ArticuloDto {
     private String leyendaVoucher;
     private BigDecimal precioVentaSinIva;
     private BigDecimal precioVentaConIva;
-    private Long cuentaVentas;
-    private Long cuentaCompras;
-    private Long cuentaGastos;
+    private Long numeroCuentaVentas;
+    private Long numeroCuentaCompras;
+    private Long numeroCuentaGastos;
     private Integer centroStockId;
     private Long rubroId;
     private Long subRubroId;
@@ -43,4 +48,7 @@ public class ArticuloDto {
     private Integer prestadorId;
     private Long autoNumericoId;
 
+    public String jsonify() {
+        return Jsonifier.builder(this).build();
+    }
 }

--- a/src/main/java/eterea/stock/service/model/dto/ArticuloStockDto.java
+++ b/src/main/java/eterea/stock/service/model/dto/ArticuloStockDto.java
@@ -2,14 +2,17 @@ package eterea.stock.service.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import eterea.stock.service.model.ArticuloDto;
-import lombok.Builder;
-import lombok.Data;
+import eterea.stock.service.util.Jsonifier;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
-@Data
+@Getter
+@Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ArticuloStockDto {
 
     private ArticuloDto articulo = null;
@@ -18,4 +21,7 @@ public class ArticuloStockDto {
     private OffsetDateTime fecha = null;
     private BigDecimal precio = BigDecimal.ZERO;
 
+    public String jsonify() {
+        return Jsonifier.builder(this).build();
+    }
 }

--- a/src/main/java/eterea/stock/service/service/dto/StockArticuloService.java
+++ b/src/main/java/eterea/stock/service/service/dto/StockArticuloService.java
@@ -6,6 +6,7 @@ import eterea.stock.service.client.ArticuloBarraClient;
 import eterea.stock.service.client.ArticuloClient;
 import eterea.stock.service.client.ArticuloFechaClient;
 import eterea.stock.service.model.dto.ArticuloStockDto;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -15,17 +16,12 @@ import java.time.OffsetDateTime;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class StockArticuloService {
 
     private final ArticuloClient articuloClient;
     private final ArticuloBarraClient articuloBarraClient;
     private final ArticuloFechaClient articuloFechaClient;
-
-    public StockArticuloService(ArticuloClient articuloClient, ArticuloBarraClient articuloBarraClient, ArticuloFechaClient articuloFechaClient) {
-        this.articuloClient = articuloClient;
-        this.articuloBarraClient = articuloBarraClient;
-        this.articuloFechaClient = articuloFechaClient;
-    }
 
     public ArticuloStockDto getStockArticulo(String codigo, OffsetDateTime fecha) {
 
@@ -33,11 +29,7 @@ public class StockArticuloService {
         try {
             // Verifica si el código enviado es nativo
             var articulo = articuloClient.findByArticuloId(codigo);
-            try {
-                log.debug("Articulo Nativo -> {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(articulo));
-            } catch (JsonProcessingException e) {
-                log.debug("Articulo Nativo -> {}", e.getMessage());
-            }
+            log.debug("Articulo Nativo -> {}", articulo.jsonify());
             var precio = articulo.getPrecioVentaConIva();
             try {
                 precio = articuloFechaClient.getByUnique(articulo.getArticuloId(), fecha).getPrecioUsd();
@@ -54,15 +46,11 @@ public class StockArticuloService {
             log.debug("Código no corresponde a Artículo");
         }
 
-        log.debug("Trying Código Barras Completo -> {}", codigo);
+        log.debug("\n\nTrying Código Barras Completo -> {}\n\n", codigo);
         try {
             // Verifica si es un código de barras completo
             var articuloBarra = articuloBarraClient.findByCodigoBarras(codigo);
-            try {
-                log.debug("Articulo de Barras -> {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(articuloBarra));
-            } catch (JsonProcessingException e) {
-                log.debug("Articulo de Barras -> {}", e.getMessage());
-            }
+            log.debug("\n\nArticulo de Barras -> {}\n\n", articuloBarra.jsonify());
             var precio = articuloBarra.getArticulo().getPrecioVentaConIva();
             try {
                 precio = articuloFechaClient.getByUnique(articuloBarra.getArticulo().getArticuloId(), fecha).getPrecioArs();
@@ -76,7 +64,7 @@ public class StockArticuloService {
                     .precio(precio)
                     .build();
         } catch (Exception e) {
-            log.debug("Código no corresponde a Artículo de Barras");
+            log.debug("\n\nCódigo no corresponde a Artículo de Barras -> {}\n\n", e.getMessage());
         }
 
         // Verifica si es un código de barras de Carnes de mi campo

--- a/src/main/java/eterea/stock/service/service/facade/AjustesService.java
+++ b/src/main/java/eterea/stock/service/service/facade/AjustesService.java
@@ -156,7 +156,7 @@ public class AjustesService {
                             .centroStockId(centroStockId)
                             .articuloId(articuloAjuste.getArticuloId())
                             .cantidad(articuloAjuste.getDiferencia())
-                            .numeroCuenta(articulo.getCuentaCompras() == null ? 0L : articulo.getCuentaCompras())
+                            .numeroCuenta(articulo.getNumeroCuentaCompras() == null ? 0L : articulo.getNumeroCuentaCompras())
                             .precioCompra(articulo.getPrecioCompra())
                             .fechaMovimiento(stockMovimiento.getFechaRegistro())
                             .centroStockId(stockMovimiento.getCentroStockIdDesde())

--- a/src/main/java/eterea/stock/service/service/facade/ControlInventarioService.java
+++ b/src/main/java/eterea/stock/service/service/facade/ControlInventarioService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import eterea.stock.service.client.InventarioClient;
 import eterea.stock.service.model.InventarioDto;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -11,13 +12,10 @@ import java.util.List;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class ControlInventarioService {
 
     private final InventarioClient inventarioClient;
-
-    public ControlInventarioService(InventarioClient inventarioClient) {
-        this.inventarioClient = inventarioClient;
-    }
 
     public List<InventarioDto> addControlInventario(List<InventarioDto> inventarios) {
         try {


### PR DESCRIPTION
Closes #26

## Descripción

Release **v1.0.0** con actualización masiva de dependencias, refactor de DTOs, simplificación de logging y mejoras en CI/CD. Incluye migración a Spring Boot 4.0.6, JDK 25, y renombre de campos en `ArticuloDto`.

## Cambios Realizados

- **Dependencias**: Spring Boot 3.5.6 → 4.0.6, Spring Cloud 2025.0.0 → 2025.1.0, SpringDoc OpenAPI 2.8.10 → 3.0.2, Apache POI 5.4.1 → 5.5.1, commons-lang3 3.18.0 → 3.20.0; nueva dependencia commons-fileupload 1.6.0
- **DTOs**: Migración de `@Data` a `@Getter/@Setter/@Builder/@NoArgsConstructor/@AllArgsConstructor` en `ArticuloDto`, `ArticuloBarraDto`, `ArticuloStockDto`; nuevo método `jsonify()` usando `Jsonifier`
- **Renombre de campos**: `cuentaVentas` → `numeroCuentaVentas`, `cuentaCompras` → `numeroCuentaCompras`, `cuentaGastos` → `numeroCuentaGastos` en `ArticuloDto`
- **Logging**: Reemplazo de `JsonMapper` manual por `jsonify()` en controladores y servicios
- **Lombok**: Migración a `@RequiredArgsConstructor` eliminando constructores manuales en 4 clases
- **CI/CD**: Actualización de Actions (checkout@v6, setup-java@v5, cache@v5, docker/login-action@v4, metadata-action@v6, buildx-action@v4, build-push-action@v7, upload-pages-artifact@v4, deploy-pages@v5); cambio de path de artefactos Pages (`_site` → `docs`)
- **Chore**: Eliminación de `<executable>true</executable>` del plugin spring-boot-maven-plugin; actualización de CHANGELOG.md, README.md y diagramas Mermaid

## Verificación

- [ ] `mvn clean verify` pasa correctamente con JDK 25
- [ ] Los DTOs serializan correctamente con `jsonify()`
- [ ] Clientes que usen `cuentaVentas`/`cuentaCompras`/`cuentaGastos` deben migrar a los nuevos nombres
