### PR TITLE
fix(model): correct ISO 8601 timezone format in DTOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.1] - 2026-06-28
+- fix: Corregido patrón de serialización de fechas ISO 8601 (`Z` → `XX`) para compatibilidad con zonas horarias en `ArticuloFechaDto`, `ArticuloMovimientoDto`, `InventarioDto`, `StockMovimientoDto` y `ArticuloStockDto`
+- chore(deps): Actualización de dependencias:
+  - Spring Boot Starter Parent 4.0.6 → 4.1.0
+  - Spring Cloud 2025.1.0 → 2025.1.2
+  - SpringDoc OpenAPI 3.0.2 → 3.0.3
+
 ## [1.0.0] - 2026-06-10
 - chore: Actualización masiva de dependencias:
   - Spring Boot Starter Parent 3.5.6 → 4.0.6

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![ETEREA.stock-service CI](https://github.com/ETEREA-services/ETEREA.stock-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/ETEREA.stock-service/actions/workflows/maven.yml)
 [![Java Version](https://img.shields.io/badge/Java-25-blue.svg)](https://www.oracle.com/java/technologies/downloads/)
-![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.6-green.svg)](https://spring.io/projects/spring-boot)
-[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-blue.svg)](https://spring.io/projects/spring-cloud)
-[![SpringDoc OpenAPI](https://img.shields.io/badge/SpringDoc%20OpenAPI-3.0.2-blue.svg)](https://springdoc.org/)
-[![Version](https://img.shields.io/badge/Version-1.0.0-blue.svg)](https://github.com/ETEREA-services/ETEREA.stock-service/releases/tag/v1.0.0)
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.1.0-green.svg)](https://spring.io/projects/spring-boot)
+[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.2-blue.svg)](https://spring.io/projects/spring-cloud)
+[![SpringDoc OpenAPI](https://img.shields.io/badge/SpringDoc%20OpenAPI-3.0.3-blue.svg)](https://springdoc.org/)
+[![Version](https://img.shields.io/badge/Version-1.0.1-blue.svg)](https://github.com/ETEREA-services/ETEREA.stock-service/releases/tag/v1.0.1)
 
 ## Descripción
 
@@ -20,9 +20,9 @@ El Servicio de Gestión de Stock es un componente esencial del sistema ETEREA qu
 ## Tecnologías Principales
 
 - **Java 25**: Lenguaje de programación principal
-- **Spring Boot 4.0.6**: Framework de desarrollo
-- **Spring Cloud 2025.1.0**: Microservicios y cloud
-- **SpringDoc OpenAPI 3.0.2**: Documentación de API
+- **Spring Boot 4.1.0**: Framework de desarrollo
+- **Spring Cloud 2025.1.2**: Microservicios y cloud
+- **SpringDoc OpenAPI 3.0.3**: Documentación de API
 - **Apache POI 5.5.1**: Procesamiento de archivos Excel
 - **Lombok**: Reducción de código boilerplate
 - **Caffeine**: Caché de alto rendimiento

--- a/docs/diagrams/mermaid/README.md
+++ b/docs/diagrams/mermaid/README.md
@@ -7,6 +7,6 @@ Este directorio contiene todos los diagramas Mermaid generados automáticamente 
 - `architecture.mmd`: Diagrama de arquitectura general del servicio.
 - `ajuste-stock-flow.mmd`: Flujo de proceso para el caso de uso de ajuste de stock.
 - `stock-adjustment-class-diagram.mmd`: Diagrama de clases UML simplificado para el ajuste de stock.
-- `dto-classes.mmd`: Diagrama de clases de los principales DTOs y relaciones. **Actualizado para versión 1.0.0**
+- `dto-classes.mmd`: Diagrama de clases de los principales DTOs y relaciones. **Actualizado para versión 1.0.1** (incluye `ArticuloFechaDto` y `CentroStockDto`)
 - `stock-adjustment-sequence-diagram.mmd`: Diagrama de secuencia para el flujo de ajuste de stock.
-- `dependencies.mmd`: Diagrama de dependencias externas (Consul v3.5.4, Feign, APIs externas).
+- `dependencies.mmd`: Diagrama de dependencias externas (Consul, Feign, APIs externas).

--- a/docs/diagrams/mermaid/dto-classes.mmd
+++ b/docs/diagrams/mermaid/dto-classes.mmd
@@ -46,9 +46,20 @@ classDiagram
     class InventarioDto
     class InventarioTurnoDto
     class StockContextDto
+    class CentroStockDto {
+        +Integer centroStockId
+        +String nombre
+    }
     class ArticuloAjusteDto
     class StockAndArticulosDto
     class StockResponseDto
+    class ArticuloFechaDto {
+        +Long articuloFechaId
+        +String articuloId
+        +String fecha
+        +BigDecimal precioUsd
+        +BigDecimal precioArs
+    }
 
     StockContextDto "1" --> "many" CentroStockDto
     StockContextDto "1" --> "many" InventarioTurnoDto
@@ -61,15 +72,3 @@ classDiagram
     InventarioDto "1" --> "1" ArticuloDto
     ArticuloStockDto "1" --> "1" ArticuloDto
     ArticuloBarraDto "1" --> "1" ArticuloDto
-    class StockAndArticulosDto {
-        +StockMovimientoDto stockMovimiento
-        +List~ArticuloMovimientoDto~ articuloMovimientos
-    }
-    class StockResponseDto {
-        +StockMovimientoDto stockMovimiento
-        +String response
-    }
-    RubroDto --> ArticuloAjusteDto
-    StockAndArticulosDto --> StockMovimientoDto
-    StockAndArticulosDto --> ArticuloMovimientoDto
-    StockResponseDto --> StockMovimientoDto

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.1.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>eterea</groupId>
     <artifactId>stock-service</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <name>ETEREA.stock-service</name>
     <description>stock-service</description>
     <url/>
@@ -28,7 +28,7 @@
     </scm>
     <properties>
         <java.version>25</java.version>
-        <spring-cloud.version>2025.1.0</spring-cloud.version>
+        <spring-cloud.version>2025.1.2</spring-cloud.version>
         <sonar.organization>eterea-services</sonar.organization>
         <sonar.projectKey>ETEREA-services_ETEREA.stock-service</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>3.0.2</version>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>

--- a/src/main/java/eterea/stock/service/model/ArticuloFechaDto.java
+++ b/src/main/java/eterea/stock/service/model/ArticuloFechaDto.java
@@ -10,7 +10,7 @@ public class ArticuloFechaDto {
 
     private Long articuloFechaId;
     private String articuloId;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private String fecha;
     private BigDecimal precioUsd;
     private BigDecimal precioArs;

--- a/src/main/java/eterea/stock/service/model/ArticuloMovimientoDto.java
+++ b/src/main/java/eterea/stock/service/model/ArticuloMovimientoDto.java
@@ -27,9 +27,9 @@ public class ArticuloMovimientoDto {
     private Long numeroCuenta;
     private Byte iva105 = 0;
     private Byte exento = 0;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaMovimiento;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaFactura;
     private Integer nivel = 0;
     private Long cierreCajaId = 0L;

--- a/src/main/java/eterea/stock/service/model/InventarioDto.java
+++ b/src/main/java/eterea/stock/service/model/InventarioDto.java
@@ -11,7 +11,7 @@ public class InventarioDto {
 
     private Long inventarioId = null;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fecha = null;
 
     private Integer inventarioTurnoId = null;

--- a/src/main/java/eterea/stock/service/model/StockMovimientoDto.java
+++ b/src/main/java/eterea/stock/service/model/StockMovimientoDto.java
@@ -25,12 +25,12 @@ public class StockMovimientoDto {
     private Integer negocioIdHasta;
     private Integer centroStockIdHasta;
     private String centroStockIdHastaNombre = "";
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaRegistro;
     private Long proveedorId;
     private Long clienteId;
     private Long legajo;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaComprobante;
     private Integer comprobanteIdFactura;
     private Integer prefijoFactura;
@@ -41,7 +41,7 @@ public class StockMovimientoDto {
     private Long cierreCajaId;
     private Long cierreRestaurantId;
     private Integer nivel = 0;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaContable;
     private Integer ordenContable;
     private Integer negocioIdOtro;

--- a/src/main/java/eterea/stock/service/model/dto/ArticuloStockDto.java
+++ b/src/main/java/eterea/stock/service/model/dto/ArticuloStockDto.java
@@ -17,7 +17,7 @@ public class ArticuloStockDto {
 
     private ArticuloDto articulo = null;
     private BigDecimal cantidad = BigDecimal.ZERO;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fecha = null;
     private BigDecimal precio = BigDecimal.ZERO;
 


### PR DESCRIPTION
Closes #28

## Descripción

Corrección de serialización ISO 8601 en DTOs, actualización de dependencias y mejoras de documentación para la versión 1.0.1.

## Cambios Realizados

- **Fix ISO 8601:** Reemplazo de `Z` por `XX` en `@JsonFormat` de 5 DTOs (`ArticuloFechaDto`, `ArticuloMovimientoDto`, `InventarioDto`, `StockMovimientoDto`, `ArticuloStockDto`)
- **Dependencias:** Spring Boot 4.0.6 → 4.1.0, Spring Cloud 2025.1.0 → 2025.1.2, SpringDoc OpenAPI 3.0.2 → 3.0.3
- **Versionado:** bump a 1.0.1
- **Documentación:** CHANGELOG, README, diagramas Mermaid actualizados

## Verificación

- [x] Compilación exitosa con `mvn clean compile`
- [x] Pruebas unitarias pasan con `mvn test`
- [x] Serialización ISO 8601 validada con zonas horarias
